### PR TITLE
Avoiding a caching issue with calling the function with different urls

### DIFF
--- a/rsj.js
+++ b/rsj.js
@@ -1,11 +1,9 @@
 exports.r2j = r2j;
 
-var FeedParser = require('feedparser')
-  , parser
-
-parser = new FeedParser();
+var FeedParser = require('feedparser');
 
 function r2j (uri,cb){
+	var parser = new FeedParser();
     parser.parseUrl(uri,function(err, meta, articles){
         if(err) return console.error(err);
         cb(JSON.stringify(articles));


### PR DESCRIPTION
FeedParser looks like it caches the url and having one instance of the parser will result in getting the same results even when changing the url. Updated the code to create a new parser on every function call to avoid this behavior. 
